### PR TITLE
SmallFix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='Automagica',
           'openpyxl==2.4.8',
           'python-docx==0.8.6',
           'pywin32==223',
-          'PyPDF2==1.26.0'
+          'PyPDF2==1.26.0',
           'psutil==5.4.6'
       ],
       include_package_data = True


### PR DESCRIPTION
It was necessary to add a comma (,) to install the package