### PR TITLE
Python syntax error: """" --> """

### DIFF
--- a/automagica/activities.py
+++ b/automagica/activities.py
@@ -6,6 +6,7 @@ import uuid
 import psutil
 from time import sleep
 import pyautogui
+import pytesseract
 '''
 Delay activities
 '''

--- a/examples/workshop/workshop_demo.py
+++ b/examples/workshop/workshop_demo.py
@@ -1,19 +1,19 @@
 """
 Initialising Automagica
-""""
+"""
 
 from automagica import *
 
 """
 Browser Automation - Opening
-""""
+"""
 
 from automagica import *
 browser = ChromeBrowser()
 
 """
 Browser Automation - Opening Google.com
-""""
+"""
 
 from automagica import *
 browser = ChromeBrowser()
@@ -21,7 +21,7 @@ browser.get('https://google.com')
 
 """
 Browser Automation - Opening Google.com and showing title
-""""
+"""
 
 from automagica import *
 browser = ChromeBrowser()
@@ -97,7 +97,7 @@ WriteListToFile(links, file="results.txt")
 
 """
 Browser Automation - Closing
-""""
+"""
 from automagica import *
 
 browser = ChromeBrowser()

--- a/examples/workshop/workshop_demo_oslo.py
+++ b/examples/workshop/workshop_demo_oslo.py
@@ -1,19 +1,19 @@
 """
 Initialising Automagica
-""""
+"""
 
 from automagica import *
 
 """
 Browser Automation - Opening
-""""
+"""
 
 from automagica import *
 browser = ChromeBrowser()
 
 """
 Browser Automation - Opening Google.com
-""""
+"""
 
 from automagica import *
 browser = ChromeBrowser()
@@ -21,7 +21,7 @@ browser.get('https://google.com')
 
 """
 Browser Automation - Opening Google.com and showing title
-""""
+"""
 
 from automagica import *
 browser = ChromeBrowser()
@@ -97,7 +97,7 @@ WriteListToFile(links, file="results.txt")
 
 """
 Browser Automation - Closing
-""""
+"""
 from automagica import *
 
 browser = ChromeBrowser()


### PR DESCRIPTION
Triple quotes are valid Python syntax but quadruple quotes are not.

[flake8](http://flake8.pycqa.org) testing of https://github.com/OakwoodAI/Automagica on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./examples/workshop/workshop_demo.py:1:3: E999 SyntaxError: EOL while scanning string literal
"""
  ^
./examples/workshop/workshop_demo_oslo.py:1:3: E999 SyntaxError: EOL while scanning string literal
"""
  ^
./automagica/activities.py:539:9: F821 undefined name 'pytesseract'
        pytesseract.pytesseract.tesseract_cmd = 'C:\\Program Files (x86)\\Tesseract-OCR\\tesseract'
        ^
2     E999 SyntaxError: EOL while scanning string literal
1     F821 undefined name 'pytesseract'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
